### PR TITLE
quick fix for broken doi links

### DIFF
--- a/app/services/sheets/cord-row-population.js
+++ b/app/services/sheets/cord-row-population.js
@@ -45,10 +45,10 @@ export default function cordRowPopulation() {
 	};
 }
 
-function resolveHttpProtocol(str, defProtocol ='http') {
+function resolveHttpProtocol(str, defProtocol ='https') {
 	if (/^http/.test(str)) {
 		return str;
 	}
 
-	return `${defProtocol}://${str}`;
+	return `${defProtocol}://doi.org/${str}`;
 }


### PR DESCRIPTION
convert refDoc['doi'] to proper url via DOI proxy server
official doc: https://www.doi.org/factsheets/DOIProxy.html#resolving

please make sure that it works